### PR TITLE
Fix missing Office icon

### DIFF
--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -1850,6 +1850,9 @@
     <!-- Microsoft Launcher -->
     <item component="ComponentInfo{com.microsoft.launcher/com.microsoft.launcher.Launcher}" drawable="microsoftlauncher"/>
 
+    <!-- Microsoft Office -->
+    <item component="ComponentInfo{com.microsoft.office.officehubrow/com.microsoft.office.officesuite.OfficeSuiteActivity}" drawable="microsoftoffice"/>
+    
     <!-- Microsoft Onedrive -->
     <item component="ComponentInfo{com.microsoft.office.skydrive/com.microsoft.skydrive.MainActivity}" drawable="microsoftonedrive" />
     <item component="ComponentInfo{com.microsoft.skydrive/com.microsoft.skydrive.MainActivity}" drawable="microsoftonedrive" />


### PR DESCRIPTION
The latest version on F-Droid (1.2.0) does not show the icon of Office and hence the PR.